### PR TITLE
Fixed broken link to Dive Into Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Keep these handy.
 If you like self-guided courses, try one of these:
 
  * [RealPython](https://realpython.com/): "Real Python teaches programming and web development through hands-on, interesting examples that are useful and fun!" (paid)
- * or _[Dive into Python](http://www.diveinto.org/python3/)_ (the classic). (Note that [Dive into Python 3](http://www.diveinto.org/python3/) only covers new & advanced features in Python 3 - not the language as a whole. Don't start there if you're new to Python) (free)
+ * or _[Dive into Python](http://www.diveintopython3.net/)_ (the classic). (Note that [Dive into Python 3](http://www.diveintopython3.net/) only covers new & advanced features in Python 3 - not the language as a whole. Don't start there if you're new to Python) (free)
  * or [Google's Python Introduction course (free)](https://developers.google.com/edu/python/)
  * or [How to Think Like a Computer Scientist: Learning with Python, Interactive Edition (free)](http://interactivepython.org/courselib/static/thinkcspy/index.html) — **if you're relatively new to programing, this is an especially good fit for you**
 


### PR DESCRIPTION
Link http://www.diveinto.org/python3/ gives a 500 Internal Server Error, replaced with http://www.diveintopython3.net/.